### PR TITLE
Hotfix remove error when editing Activity without socis

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -96,10 +96,12 @@ class ActivityController extends Controller
         $activity->users()->sync($request->get('user'));
         $socis = $request->socis;
 
-        foreach($socis as $soci){
-            $user = User::where('id', $soci)->first();
-            $user->activities()->attach($activity);
+        if (isset($socis) == true) {
+            foreach($socis as $soci){
+                $user = User::where('id', $soci)->first();
+                $user->activities()->attach($activity);
             }
+        }
 
         if($file = $request->file('file'))
         {


### PR DESCRIPTION
Make sure there is no error when editing an activity without any soci assigned